### PR TITLE
FEATURE: Optional repository management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@
 # #master: salt
 # <% end -%>
 #
-# this makes crafting templates a simple matter of running 
+# this makes crafting templates a simple matter of running
 # few lines bash script :)
 #
 # ==== Minion parameters
@@ -43,9 +43,15 @@
 #   Defines if to install salt-master, can be true or false
 #   default value: false
 #
-# [*version*] 
+# [*version*]
 #   Which version of package to install,can be present, latest, absent or <version>
 #   default value: present
+#
+# [*manage_repo*]
+#   Set to true if you want to make use of the yum/apt repos
+#   as managed in the salt::repos class in this module.
+#   Requires either the example42 apt module or yum module, as appropriate.
+#   default value: false
 #
 # [*master_conf_file*]
 #   Configuration file for salt master
@@ -79,6 +85,7 @@
 class salt (
   $master                          = false,
   $version                         = present,
+  $manage_repo                     = false,
   $master_conf_file                = $salt::defaults::master_conf_file,
   $minion_conf_file                = $salt::defaults::minion_conf_file,
   $master_conf_template            = $salt::defaults::master_conf_template,
@@ -119,6 +126,11 @@ class salt (
   $minion_tcp_pull_port            = undef,
 ) inherits salt::defaults {
 
+  # Repo management
+  if $manage_repo {
+    include salt::repo
+  }
+
   # salt-master
   if $master {
     class {'salt::master':}
@@ -127,3 +139,5 @@ class salt (
   # salt-minion
   class {'salt::minion':}
 }
+# vim:shiftwidth=2:tabstop=2:softtabstop=2:expandtab:smartindent
+

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,0 +1,17 @@
+# Class salt::repo
+# Set up the package repo for rpm/deb based distros
+class salt::repo {
+  case $::osfamily {
+    /(Debian|Ubuntu)/: {
+      include salt::repo::deb
+    }
+    /(Redhat|Centos)/: {
+      include salt::repo::rpm
+    }
+    default: {
+      fail("${::osfamily} is not yet supported. Add it and send a pull request!")
+    }
+  }
+}
+# vim:shiftwidth=2:tabstop=2:softtabstop=2:expandtab:smartindent
+

--- a/manifests/repo/deb.pp
+++ b/manifests/repo/deb.pp
@@ -1,0 +1,43 @@
+# Class salt::repo::deb
+# Handle .deb based distributions' repositories for Saltstack
+# Requires example42's apt module - https://github.com/example42/puppet-apt
+class salt::repo::deb {
+
+  case $::operatingsystem {
+    'Ubuntu': { # http://docs.saltstack.com/topics/installation/ubuntu.html
+      apt::repository {'saltstack-ppa':
+        url        => 'http://ppa.launchpad.net/saltstack/salt/ubuntu',
+        distro     => $::lsbdistcodename,
+        repository => 'main',
+        key        => '0x4759fa960e27c0a6',
+        key_server => 'keyserver.ubuntu.com',
+      }
+    }
+    'Debian': { # http://docs.saltstack.com/topics/installation/debian.html
+      apt::key {'F2AE6AB9':
+        url => 'http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key',
+      }
+      $deb_base_url = 'http://debian.saltstack.com/debian'
+      case $::lsbdistcodename {
+        /(squeeze|wheezy)/: {
+          apt::repository {"${::lsbdistcodename}-saltstack":
+            url        => $deb_base_url,
+            distro     => $::lsbdistcodename,
+            repository => 'main',
+          }
+        }
+        'sid': {
+          apt::repository {'sid-saltstack':
+            url        => $deb_base_url,
+            distro     => 'unstable',
+            repository => 'main',
+          }
+        }
+        default  : { fail("${::lsbdistcodename} is not yet supported, Add it and send a pull request!") }
+      }
+    }
+    default: { fail("${::operatingsystem} is not yet supported, Add it and send a pull request!") }
+  }
+}
+# vim:shiftwidth=2:tabstop=2:softtabstop=2:expandtab:smartindent
+

--- a/manifests/repo/rpm.pp
+++ b/manifests/repo/rpm.pp
@@ -1,0 +1,6 @@
+# To enable in RHEL, you just need EPEL repos
+# See http://docs.saltstack.com/topics/installation/rhel.html
+#
+# TODO: Add checks for EPEL on RHEL
+#
+# For Fedora, saltstack is in the standard repos.


### PR DESCRIPTION
Add a parameter ($manage_repo) that defaults to false
which, if set to true, sets up the appropriate package
repository for saltstack to be installed

Currently, only dpkg-based distributions are actioned,
the rpm page is just comments pointing to the saltstack docs.
