### PR TITLE
Corrected default Parameter / Migration to puppetlabs-apt usage

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,7 +134,7 @@ class salt (
   $master_minion_data_cache        = undef,
   $master_auto_accept              = undef,
   $master_sock_dir                 = undef,
-  $master_nodegroups               = {},
+  $master_nodegroups               = undef,
   $minion_master                   = undef,
   $minion_master_port              = undef,
   $minion_user                     = undef,

--- a/manifests/repo/deb.pp
+++ b/manifests/repo/deb.pp
@@ -1,36 +1,34 @@
 # Class salt::repo::deb
 # Handle .deb based distributions' repositories for Saltstack
-# Requires example42's apt module - https://github.com/example42/puppet-apt
+# Requires Puppetlabs apt modules!
 class salt::repo::deb {
+  include apt
 
   case $::operatingsystem {
     'Ubuntu': { # http://docs.saltstack.com/topics/installation/ubuntu.html
-      apt::repository {'saltstack-ppa':
-        url        => 'http://ppa.launchpad.net/saltstack/salt/ubuntu',
-        distro     => $::lsbdistcodename,
-        repository => 'main',
-        key        => '0x4759fa960e27c0a6',
-        keyserver  => 'keyserver.ubuntu.com',
-      }
+      apt::ppa { 'ppa:saltstack/salt': }
     }
     'Debian': { # http://docs.saltstack.com/topics/installation/debian.html
-      apt::key {'F2AE6AB9':
-        url => 'http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key',
-      }
-      $deb_base_url = 'http://debian.saltstack.com/debian'
+      $deb_base_url   = 'http://debian.saltstack.com/debian'
+      $deb_key        = 'F2AE6AB9'
+      $deb_key_source = 'http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key'
       case $::lsbdistcodename {
-        /(squeeze|wheezy)/: {
-          apt::repository {"${::lsbdistcodename}-saltstack":
-            url        => $deb_base_url,
-            distro     => $::lsbdistcodename,
-            repository => 'main',
+        /(squeeze|wheezy|jessie)/: {
+          apt::source {'saltstack':
+            location   => $deb_base_url,
+            release    => "${::lsbdistcodename}-saltstack",
+            repos      => 'main',
+            key        => $deb_key,
+            key_source => $deb_key_source,
           }
         }
         'sid': {
-          apt::repository {'sid-saltstack':
-            url        => $deb_base_url,
-            distro     => 'unstable',
-            repository => 'main',
+          apt::soruce {'saltstack':
+            location   => $deb_base_url,
+            release    => 'unstable',
+            repos      => 'main',
+            key        => $deb_key,
+            key_source => $deb_key_source,
           }
         }
         default  : { fail("${::lsbdistcodename} is not yet supported, Add it and send a pull request!") }


### PR DESCRIPTION
I hope you agree to merge the two changes:
1.  The `$master_nodgroups` parameter should have a default of `undef`, otherwise the master template creates a unnecessary nodegroup entry, when the parameter is an emtpy hash.
2. The common module to use for handling apt repositories is `puppetlabs-apt`. So I converted the `salt::repo::deb` class to the corresponding resources.
