### PR TITLE
Ordering fix / ubuntu fix / updated configfiles

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    apt: 'git://git@github.com:puppetlabs/puppetlabs-apt.git'
+    apt: 'git://github.com/puppetlabs/puppetlabs-apt.git'
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
   symlinks:
     salt: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    apt: 'git@github.com:puppetlabs/puppetlabs-apt.git'
+    apt: 'git://git@github.com:puppetlabs/puppetlabs-apt.git'
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
   symlinks:
     salt: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,6 @@
 fixtures:
   repositories:
-    puppi: 'git://github.com/example42/puppi.git'
-    apt: 'git://github.com/example42/puppet-apt.git'
+    apt: 'git@github.com:puppetlabs/puppetlabs-apt.git'
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
   symlinks:
     salt: "#{source_dir}"

--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -23,4 +23,14 @@ class salt::defaults {
   $grains_file = $::operatingsystem ? {
     default => '/etc/salt/grains',
   }
+
+  case $::operatingsystem {
+    /Ubuntu/: {
+      # salt only installs init style scripts
+      $service_provider = debian
+    }
+    default: {
+      $service_provider = undef
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,7 +159,18 @@ class salt (
 
   # Repo management
   if $manage_repo {
+
     include salt::repo
+
+    # ensure correct order
+    Class['salt::repo']
+    -> Class['salt::minion']
+
+    # ensure order also if master is installed
+    if $master {
+      Class['salt::repo']
+      -> Class['salt::master']
+    }
   }
 
   # salt-master

--- a/manifests/master/service.pp
+++ b/manifests/master/service.pp
@@ -1,7 +1,8 @@
 # service for salt master
 class salt::master::service {
   service { 'salt-master':
-    ensure => 'running',
-    enable => true,
+    ensure   => 'running',
+    enable   => true,
+    provider => $salt::defaults::service_provider,
   }
 }

--- a/manifests/minion/service.pp
+++ b/manifests/minion/service.pp
@@ -1,6 +1,7 @@
 class salt::minion::service {
   service { 'salt-minion':
-    ensure => 'running',
-    enable => true,
+    ensure   => 'running',
+    enable   => true,
+    provider => $salt::defaults::service_provider,
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,12 +1,20 @@
 # Class salt::repo
 # Set up the package repo for rpm/deb based distros
 class salt::repo {
+  # anchor classes for correcect containment
+  # (in puppet > 3.4 'contain' would be better/easier)
+  anchor{['salt::repo_begin', 'salt::repo_end']: }
+
   case $::osfamily {
     /(Debian|Ubuntu)/: {
-      include salt::repo::deb
+      Anchor['salt::repo_begin']
+      -> class{'salt::repo::deb': }
+      -> Anchor['salt::repo_end']
     }
     /(Redhat|Centos)/: {
-      include salt::repo::rpm
+      Anchor['salt::repo_begin']
+      -> class{'salt::repo::rpm': }
+      -> Anchor['salt::repo_end']
     }
     default: {
       fail("${::osfamily} is not yet supported. Add it and send a pull request!")

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -5,7 +5,7 @@ class salt::repo {
   # (in puppet > 3.4 'contain' would be better/easier)
   anchor { ['salt::repo::begin', 'salt::repo::end']: }
 
-  case $::osfamily {
+  case $::operatingsystem {
     /(Debian|Ubuntu)/: {
       Anchor['salt::repo::begin'] ->
       class {'salt::repo::deb': } ->

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,18 +3,18 @@
 class salt::repo {
   # anchor classes for correcect containment
   # (in puppet > 3.4 'contain' would be better/easier)
-  anchor{['salt::repo_begin', 'salt::repo_end']: }
+  anchor { ['salt::repo::begin', 'salt::repo::end']: }
 
   case $::osfamily {
     /(Debian|Ubuntu)/: {
-      Anchor['salt::repo_begin']
-      -> class{'salt::repo::deb': }
-      -> Anchor['salt::repo_end']
+      Anchor['salt::repo::begin'] ->
+      class {'salt::repo::deb': } ->
+      Anchor['salt::repo::end']
     }
     /(Redhat|Centos)/: {
-      Anchor['salt::repo_begin']
-      -> class{'salt::repo::rpm': }
-      -> Anchor['salt::repo_end']
+      Anchor['salt::repo::begin'] ->
+      class {'salt::repo::rpm': } ->
+      Anchor['salt::repo::end']
     }
     default: {
       fail("${::osfamily} is not yet supported. Add it and send a pull request!")

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -6,29 +6,29 @@ describe "salt::repo" do
 
   context 'with os = Centos' do
     let(:facts) { {:operatingsystem => 'Centos', :osfamily => 'Redhat'} }
-    it { should include_class('salt::repo::rpm')}
+    it { should contain_class('salt::repo::rpm')}
   end
   context 'with os = Redhat' do
     let(:facts) { {:operatingsystem => 'Redhat', :osfamily => 'Redhat'} }
-    it { should include_class('salt::repo::rpm')}
+    it { should contain_class('salt::repo::rpm')}
   end
   context 'with os = Ubuntu saucy' do
-    let(:facts) { {:operatingsystem => 'Ubuntu', :osfamily => 'Debian', :lsbdistcodename => 'saucy'} }
-    it { should include_class('salt::repo::deb')}
+    let(:facts) { {:operatingsystem => 'Ubuntu', :osfamily => 'Debian', :lsbdistid => 'Ubuntu', :lsbdistcodename => 'saucy'} }
+    it { should contain_class('salt::repo::deb')}
   end
   context 'with os = Debian squeeze' do
-    let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'squeeze'} }
-    it { should include_class('salt::repo::deb')}
+    let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistcodename => 'squeeze'} }
+    it { should contain_class('salt::repo::deb')}
   end
 end
 
 describe "salt::repo::deb" do
   context 'with os = Ubuntu saucy' do
-    let(:facts) { {:operatingsystem => 'Ubuntu', :osfamily => 'Debian', :lsbdistcodename => 'saucy'} }
+    let(:facts) { {:operatingsystem => 'Ubuntu', :osfamily => 'Debian', :lsbdistid => 'Ubuntu', :lsbdistcodename => 'saucy'} }
       it { should create_class('salt::repo::deb')}
     end
   context 'with os = Debian squeeze' do
-    let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', :lsbdistcodename => 'squeeze'} }
+    let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistcodename => 'squeeze'} }
     it { should create_class('salt::repo::deb')}
   end
 end

--- a/spec/classes/salt_init_spec.rb
+++ b/spec/classes/salt_init_spec.rb
@@ -7,8 +7,8 @@ describe "salt" do
 # Minion config
   context 'with minion_master => undef' do
     it do
-      should include_class('salt::minion')
-      should include_class('salt::minion::install')
+      should contain_class('salt::minion')
+      should contain_class('salt::minion::install')
       should contain_file('minion-conf').with({
         'ensure' => 'present',
         'owner'  => 'root',

--- a/spec/classes/salt_init_spec.rb
+++ b/spec/classes/salt_init_spec.rb
@@ -26,6 +26,16 @@ describe "salt" do
       .with_content(/^master: host.example.com/) 
     end
   end
+  context 'with os = Ubuntu saucy' do
+    let(:facts) { {:operatingsystem => 'Ubuntu', :osfamily => 'Debian', :lsbdistid => 'Ubuntu', :lsbdistcodename => 'saucy'} }
+    it do
+      should contain_service('salt-minion').with({
+        'ensure'   => 'running',
+        'enable'   => true,
+        'provider' => 'debian',
+      })
+    end
+  end
 
 
 # Master config

--- a/templates/master.erb
+++ b/templates/master.erb
@@ -28,9 +28,10 @@ publish_port: <%= @master_publish_port %>
 #publish_port: 4505
 <% end -%>
 
-# The user to run the salt-master as. Salt will update all permissions to
-# allow the specified user to run the master. If the modified files cause
-# conflicts set verify_env to False.
+# The user under which the salt master will run. Salt will update all
+# permissions to allow the specified user to run the master. The exception is
+# the job cache, which must be deleted if this user is changed.  If the
+# modified files cause conflicts set verify_env to False.
 <% if @master_user -%>
 user: <%= @master_user %>
 <% else -%>
@@ -84,7 +85,8 @@ pidfile: <%= @master_pidfile %>
 <% end -%>
 
 # The root directory prepended to these options: pki_dir, cachedir,
-# sock_dir, log_file, autosign_file, extension_modules, key_logfile, pidfile.
+# sock_dir, log_file, autosign_file, autoreject_file, extension_modules,
+# key_logfile, pidfile.
 <% if @master_root_dir -%>
 root_dir: <%= @master_root_dir %>
 <% else -%>
@@ -138,6 +140,12 @@ sock_dir: <%= @master_sock_dir %>
 #sock_dir: /var/run/salt/master
 <% end -%>
 
+# The master can take a while to start up when lspci and/or dmidecode is used
+# to populate the grains for the master. Enable if you want to see GPU hardware
+# data for your master.
+#
+# enable_gpu_grains: False
+
 # The master maintains a job cache, while this is a great addition it can be
 # a burden on the master for larger deployments (over 5000 minions).
 # Disabling the job cache will make previously executed jobs unavailable to
@@ -188,9 +196,14 @@ auto_accept: <%= @master_auto_accept %>
 #auto_accept: False
 <% end -%>
 
-# If the autosign_file is specified only incoming keys specified in
-# the autosign_file will be automatically accepted. This is insecure.
-# Regular expressions as well as globing lines are supported.
+# If the autosign_file is specified, incoming keys specified in the
+# autosign_file will be automatically accepted. This is insecure.  Regular
+# expressions as well as globing lines are supported.
+#autosign_file: /etc/salt/autosign.conf
+
+# Works like autosign_file, but instead allows you to specify minion IDs for
+# which keys will automatically be rejected. Will override both membership in
+# the autosign_file and the auto_accept setting.
 #autosign_file: /etc/salt/autosign.conf
 
 # Enable permissive access to the salt keys.  This allows you to run the
@@ -240,7 +253,29 @@ auto_accept: <%= @master_auto_accept %>
 
 # Allow minions to push files to the master. This is disabled by default, for
 # security purposes.
-#file_recv: False 
+#file_recv: False
+
+# Set a hard-limit on the size of the files that can be pushed to the master.
+# It will be interpreted as megabytes.
+# Default: 100
+#file_recv_max_size: 100
+
+# Signature verification on messages published from the master.
+# This causes the master to cryptographically sign all messages published to its event
+# bus, and minions then verify that signature before acting on the message.
+#
+# This is False by default.
+#
+# Note that to facilitate interoperability with masters and minions that are different
+# versions, if sign_pub_messages is True but a message is received by a minion with
+# no signature, it will still be accepted, and a warning message will be logged.
+# Conversely, if sign_pub_messages is False, but a minion receives a signed
+# message it will be accepted, the signature will not be checked, and a warning message
+# will be logged.  This behavior will go away in Salt 0.17.6 (or Hydrogen RC1, whichever
+# comes first) and these two situations will cause minion to throw an exception and
+# drop the message.
+#
+# sign_pub_messages: False
 
 #####    Master Module Management    #####
 ##########################################
@@ -278,6 +313,19 @@ auto_accept: <%= @master_auto_accept %>
 
 # The renderer to use on the minions to render the state data
 #renderer: yaml_jinja
+
+# The Jinja renderer can strip extra carriage returns and whitespace
+# See http://jinja.pocoo.org/docs/api/#high-level-api
+#
+# If this is set to True the first newline after a Jinja block is removed
+# (block, not variable tag!). Defaults to False, corresponds to the Jinja
+# environment init variable "trim_blocks".
+# jinja_trim_blocks: False
+#
+# If this is set to True leading spaces and tabs are stripped from the start
+# of a line to a block. Defaults to False, corresponds to the Jinja
+# environment init variable "lstrip_blocks".
+# jinja_lstrip_blocks: False
 
 # The failhard option tells the minions to stop immediately after the first
 # failure detected in the state execution, defaults to False
@@ -366,7 +414,34 @@ auto_accept: <%= @master_auto_accept %>
 #fileserver_backend:
 #  - git
 #  - roots
-
+#
+# Uncomment the line below if you do not want the file_server to follow
+# symlinks when walking the filesystem tree. This is set to True
+# by default. Currently this only applies to the default roots
+# fileserver_backend.
+#
+#fileserver_followsymlinks: False
+#
+# Uncomment the line below if you do not want symlinks to be
+# treated as the files they are pointing to. By default this is set to
+# False. By uncommenting the line below, any detected symlink while listing
+# files on the Master will not be returned to the Minion.
+#
+#fileserver_ignoresymlinks: True
+#
+# By default, the Salt fileserver recurses fully into all defined environments
+# to attempt to find files. To limit this behavior so that the fileserver only
+# traverses directories with SLS files and special Salt directories like _modules,
+# enable the option below. This might be useful for installations where a file root
+# has a very large number of files and performance is impacted. Default is False.
+#
+# fileserver_limit_traversal: False
+#
+# The fileserver can fire events off every time the fileserver is updated,
+# these are disabled by default, but can be easily turned on by setting this
+# flag to True
+#fileserver_events: False
+#
 # Git fileserver backend configuration
 # When using the git fileserver backend at least one git remote needs to be
 # defined. The user running the salt master will need read access to the repo.
@@ -375,13 +450,20 @@ auto_accept: <%= @master_auto_accept %>
 #  - git://github.com/saltstack/salt-states.git
 #  - file:///var/git/saltmaster
 #
+# The gitfs_ssl_verify option specifies whether to ignore ssl certificate
+# errors when contacting the gitfs backend. You might want to set this to
+# false if you're using a git backend that uses a self-signed certificate but
+# keep in mind that setting this flag to anything other than the default of True
+# is a security concern, you may want to try using the ssh transport.
+#gitfs_ssl_verify: True
+#
 # The repos will be searched in order to find the file requested by a client
 # and the first repo to have the file will return it.
 # When using the git backend branches and tags are translated into salt
 # environments.
 # Note:  file:// repos will be treated as a remote, so refs you want used must
 # exist in that repo as *local* refs.
-#     
+#
 # The gitfs_root option gives the ability to serve files from a subdirectory
 # within the repository. The path is defined relative to the root of the
 # repository and defaults to the repository root.
@@ -403,6 +485,13 @@ auto_accept: <%= @master_auto_accept %>
 #ext_pillar:
 #  - hiera: /etc/hiera.yaml
 #  - cmd_yaml: cat /etc/salt/yaml
+
+# The pillar_gitfs_ssl_verify option specifies whether to ignore ssl certificate
+# errors when contacting the pillar gitfs backend. You might want to set this to
+# false if you're using a git backend that uses a self-signed certificate but
+# keep in mind that setting this flag to anything other than the default of True
+# is a security concern, you may want to try using the ssh transport.
+#pillar_gitfs_ssl_verify: True
 
 # The pillar_opts option adds the master configuration file data to a dict in
 # the pillar called "master". This is used to set simple configurations in the
@@ -480,6 +569,26 @@ auto_accept: <%= @master_auto_accept %>
 #  foo.example.com:
 #    - manage.up
 
+#####         Mine settings     #####
+##########################################
+# Restrict mine.get access from minions. By default any minion has a full access
+# to get all mine data from master cache. In acl definion below, only pcre matches
+# are allowed.
+#
+# mine_get:
+#   .*:
+#     - .*
+#
+# Example below enables minion foo.example.com to get  'network.interfaces' mine data only
+# , minions web* to get all network.* and disk.* mine data and all other minions won't get
+# any mine data.
+#
+# mine_get:
+#   foo.example.com:
+#     - network.inetrfaces
+#   web.*:
+#     - network.*
+#     - disk.*
 
 #####         Logging settings       #####
 ##########################################

--- a/templates/minion.erb
+++ b/templates/minion.erb
@@ -163,6 +163,10 @@ acceptance_wait_time_max: <%= @minion_acceptance_wait_time_max %>
 #acceptance_wait_time_max: 0
 <% end -%>
 
+# If the master rejects the minion's public key, retry instead exiting. Rejected keys
+# # will be handled the same as waiting on acceptance.
+#rejected_retry: False
+
 # When the master key changes, the minion will try to re-auth itself to receive
 # the new master key. In larger environments this can cause a SYN flood on the
 # master because all minions try to re-auth immediately. To prevent this and
@@ -175,6 +179,13 @@ random_reauth_delay: <%= @minion_random_reauth_delay %>
 #random_reauth_delay: 60
 <% end -%>
 
+# When waiting for a master to accept the minion's public key, salt will
+# continuously attempt to reconnect until successful. This is the timeout value,
+# in seconds, for each individual attempt. After this timeout expires, the minion
+# will wait for acceptance_wait_time seconds before trying again.
+# Unless your master is under unusually heavy load, this should be left at the default.
+#auth_timeout: 3
+
 
 # If you don't have any problems with syn-floods, dont bother with the
 # three recon_* settings described below, just leave the defaults!
@@ -183,10 +194,10 @@ random_reauth_delay: <%= @minion_random_reauth_delay %>
 # to reconnect immediately, if the socket is disconnected (for example if
 # the master processes are restarted). In large setups this will have all
 # minions reconnect immediately which might flood the master (the ZeroMQ-default
-# is usually a 100ms delay). To prevent this, these three recon_* settings 
+# is usually a 100ms delay). To prevent this, these three recon_* settings
 # can be used.
 #
-# recon_default: the interval in milliseconds that the socket should wait before 
+# recon_default: the interval in milliseconds that the socket should wait before
 #                trying to reconnect to the master (100ms = 1 second)
 #
 # recon_max: the maximum time a socket should wait. each interval the time to wait
@@ -200,14 +211,14 @@ random_reauth_delay: <%= @minion_random_reauth_delay %>
 #            reconnect 5: value from previous interval * 2
 #            reconnect x: if value >= recon_max, it starts again with recon_default
 #
-# recon_randomize: generate a random wait time on minion start. The wait time will 
-#                  be a random value between recon_default and recon_default + 
-#                  recon_max. Having all minions reconnect with the same recon_default 
-#                  and recon_max value kind of defeats the purpose of being able to 
-#                  change these settings. If all minions have the same values and your 
-#                  setup is quite large (several thousand minions), they will still 
+# recon_randomize: generate a random wait time on minion start. The wait time will
+#                  be a random value between recon_default and recon_default +
+#                  recon_max. Having all minions reconnect with the same recon_default
+#                  and recon_max value kind of defeats the purpose of being able to
+#                  change these settings. If all minions have the same values and your
+#                  setup is quite large (several thousand minions), they will still
 #                  flood the master. The desired behaviour is to have timeframe within
-#                  all minions try to reconnect. 
+#                  all minions try to reconnect.
 
 # Example on how to use these settings:
 # The goal: have all minions reconnect within a 60 second timeframe on a disconnect
@@ -219,9 +230,9 @@ random_reauth_delay: <%= @minion_random_reauth_delay %>
 #
 # Each minion will have a randomized reconnect value between 'recon_default'
 # and 'recon_default + recon_max', which in this example means between 1000ms
-# 60000ms (or between 1 and 60 seconds). The generated random-value will be 
-# doubled after each attempt to reconnect. Lets say the generated random 
-# value is 11 seconds (or 11000ms). 
+# 60000ms (or between 1 and 60 seconds). The generated random-value will be
+# doubled after each attempt to reconnect. Lets say the generated random
+# value is 11 seconds (or 11000ms).
 #
 # reconnect 1: wait 11 seconds
 # reconnect 2: wait 22 seconds
@@ -245,6 +256,28 @@ random_reauth_delay: <%= @minion_random_reauth_delay %>
 # sane 60 seconds, but if the minion scheduler needs to be evaluated more
 # often lower this value
 #loop_interval: 60
+
+# The grains_refresh_every setting allows for a minion to periodically check
+# its grains to see if they have changed and, if so, to inform the master
+# of the new grains. This operation is moderately expensive, therefore
+# care should be taken not to set this value too low.
+#
+# Note: This value is expressed in __minutes__!
+#
+# A value of 10 minutes is a reasonable default.
+#
+# If the value is set to zero, this check is disabled.
+#grains_refresh_every = 1
+
+# Cache grains on the minion. Default is False.
+# grains_cache: False
+
+# Grains cache expiration, in seconds. If the cache file is older than this
+# number of seconds then the grains cache will be dumped and fully re-populated
+# with fresh data. Defaults to 5 minutes. Will have no effect if 'grains_cache'
+# is not enabled.
+# grains_cache_expiration: 300
+
 
 # When healing, a dns_check is run. This is to make sure that the originally
 # resolved dns has not changed. If this is something that does not happen in
@@ -318,6 +351,13 @@ tcp_pull_port: <%= @minion_tcp_pull_port %>
 # Enable Cython modules searching and loading. (Default: False)
 #cython_enable: False
 #
+#
+#
+# Specify a max size (in bytes) for modules on import
+# this feature is currently only supported on *nix OSs and requires psutil
+# modules_max_memory: -1
+
+
 
 #####    State Management Settings    #####
 ###########################################
@@ -404,6 +444,16 @@ tcp_pull_port: <%= @minion_tcp_pull_port %>
 #file_roots:
 #  base:
 #    - /srv/salt
+
+# By default, the Salt fileserver recurses fully into all defined environments
+# to attempt to find files. To limit this behavior so that the fileserver only
+# traverses directories with SLS files and special Salt directories like _modules,
+# enable the option below. This might be useful for installations where a file root
+# has a very large number of files and performance is negatively impacted.
+#
+# Default is False.
+#
+# fileserver_limit_traversal: False
 
 # The hash_type is the hash to use when discovering the hash of a file in
 # the local fileserver. The default is md5, but sha1, sha224, sha256, sha384


### PR DESCRIPTION
Hi, please insert this patch fixing three things:
1. included correct ordering in managing repositories and installing packages (addition to my last patch). This is mainly due to the lack of containtment.
2. update of comments in configuration files (typos and new parameters) from newest salt release
3. force `service` to use the debian provider on ubuntu, since no upstart scripts provided.
