### PR TITLE
Update to puppet 4

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -1,6 +1,8 @@
 # defaults for salt module
 class salt::defaults {
 
+  # Only needed for windows
+  $temp_installer = 'C:\ProgramData\PuppetLabs\Salt-Minion-2016.3.4-AMD64-Setup.exe'
   # set location of conf file for master
   #
   $master_conf_file = $::operatingsystem ? {
@@ -9,8 +11,21 @@ class salt::defaults {
 
   # set location of conf file for minion
   #
-  $minion_conf_file = $::operatingsystem ? {
-    default => '/etc/salt/minion',
+  $minion_conf_file = $::kernel ? {
+    'Linux'   => '/etc/salt/minion',
+    'Windows' => 'C:\salt\conf\minion',
+    default   => '/etc/salt/minion',
+  }
+
+  $user = $::kernel ? {
+    'Linux'   => 'root',
+    'Windows' => 'SYSTEM',
+    default   => 'root',
+  }
+  $group = $::kernel ? {
+    'Linux'   => 'root',
+    'Windows' => 'administrators',
+    default   => 'root',
   }
 
   # set templates for master and minion
@@ -20,17 +35,26 @@ class salt::defaults {
 
   # set location of grains file
   #
-  $grains_file = $::operatingsystem ? {
-    default => '/etc/salt/grains',
+  $grains_file = $::kernel ? {
+    'Linux'   => '/etc/salt/grains',
+    'Windows' => 'C:\salt\conf\grains',
+    default   => '/etc/salt/grains',
   }
 
-  case $::operatingsystem {
-    /Ubuntu/: {
-      # salt only installs init style scripts
-      $service_provider = debian
+  case $::kernel {
+    'Linux': {
+      case $::operatingsystem {
+        /Ubuntu/: {
+          # salt only installs init style scripts
+          $service_provider = debian
+        }
+        default: {
+          $service_provider = undef
+        }
+      }
     }
-    default: {
-      $service_provider = undef
+    'Windows': {
+      $service_provider = windows
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,6 +155,7 @@ class salt (
   $minion_ipc_mode                 = undef,
   $minion_tcp_pub_port             = undef,
   $minion_tcp_pull_port            = undef,
+  $minion_grains                   = undef,
 ) inherits salt::defaults {
 
   # Repo management
@@ -183,4 +184,3 @@ class salt (
   class {'salt::minion':}
 }
 # vim:shiftwidth=2:tabstop=2:softtabstop=2:expandtab:smartindent
-

--- a/manifests/master/config.pp
+++ b/manifests/master/config.pp
@@ -1,5 +1,5 @@
 # config for master
-class salt::master::config {
+class salt::master::config inherits salt {
   file { 'master-conf':
     ensure  => present,
     path    => $salt::master_conf_file,

--- a/manifests/minion/config.pp
+++ b/manifests/minion/config.pp
@@ -1,4 +1,4 @@
-class salt::minion::config {
+class salt::minion::config inherits salt {
   file { 'minion-conf':
     ensure  => present,
     path    => $salt::minion_conf_file,

--- a/manifests/minion/config.pp
+++ b/manifests/minion/config.pp
@@ -1,19 +1,19 @@
 class salt::minion::config inherits salt {
-  file { 'minion-conf':
+  file { "$salt::minion_conf_file":
     ensure  => present,
     path    => $salt::minion_conf_file,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $salt::user,
+    group   => $salt::group,
     mode    => '0644',
     content => template($salt::minion_conf_template),
   }
 
   if $salt::facter_include {
-    file { 'grains':
+    file { "$salt::grains_file":
       ensure  => present,
       path    => $salt::grains_file,
-      owner   => 'root',
-      group   => 'root',
+      owner   => $salt::user,
+      group   => $salt::group,
       mode    => '0644',
       content => template('salt/grains.erb'),
     }

--- a/manifests/minion/install.pp
+++ b/manifests/minion/install.pp
@@ -14,7 +14,7 @@ class salt::minion::install inherits salt {
         #mode => '0644',
         source => "puppet:///modules/salt/Salt-Minion-2016.3.4-AMD64-Setup.exe",
       } ->
-      package { 'salt-minion':
+      package { 'Salt Minion 2016.3.4':
         ensure   => $ensure_setting,
         source   => "$temp_installer",
         install_options => ['/S']

--- a/manifests/minion/install.pp
+++ b/manifests/minion/install.pp
@@ -1,5 +1,33 @@
-class salt::minion::install {
-  package { 'salt-minion':
-    ensure => $salt::version,
-  }
+class salt::minion::install inherits salt {
+
+  case $::kernel {
+    'Linux'   : {
+      package { 'salt-minion':
+        ensure => $salt::version,
+      }
+    }
+    'Windows' : {
+      # puppet file server as msi package source is not supported
+      # https://docs.puppetlabs.com/puppet/4.4/reference/resources_package_windows.html
+      file { "$salt::temp_installer":
+        ensure => present,
+        #mode => '0644',
+        source => "puppet:///modules/salt/Salt-Minion-2016.3.4-AMD64-Setup.exe",
+      } ->
+      package { 'salt-minion':
+        ensure   => $ensure_setting,
+        source   => "$temp_installer",
+        install_options => ['/S']
+      }
+      #exec { 'install_minion_service':
+      #  command   => '"C:\ProgramData\PuppetLabs\Salt-Minion-2016.3.4-AMD64-Setup.exe" /S',
+      #  unless    => 'C:\\windows\\system32\\cmd.exe /c sc.exe query salt-minion',
+      #}
+    } # end Windows
+    default   : {
+      # lint:ignore:80chars
+      fail("The Salt-minion module is not yet supported on this ${::kernel}")
+      # lint:endignore
+    }
+  } # end $::kernel case
 }

--- a/manifests/repo/deb.pp
+++ b/manifests/repo/deb.pp
@@ -5,30 +5,55 @@ class salt::repo::deb {
   include apt
 
   case $::operatingsystem {
-    'Ubuntu': { # http://docs.saltstack.com/topics/installation/ubuntu.html
-      apt::ppa { 'ppa:saltstack/salt': }
-    }
-    'Debian': { # http://docs.saltstack.com/topics/installation/debian.html
-      $deb_base_url   = 'http://debian.saltstack.com/debian'
-      $deb_key        = 'F2AE6AB9'
-      $deb_key_source = 'http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key'
+    'Ubuntu': {
       case $::lsbdistcodename {
-        /(squeeze|wheezy|jessie)/: {
+        'precise': {
           apt::source {'saltstack':
-            location   => $deb_base_url,
-            release    => "${::lsbdistcodename}-saltstack",
+            location   => 'http://repo.saltstack.com/apt/ubuntu/12.04/amd64/2016.3',
+            release    => "${::lsbdistcodename}",
             repos      => 'main',
-            key        => $deb_key,
-            key_source => $deb_key_source,
+            key        => 'DE57BFBE',
+            key_source => 'https://repo.saltstack.com/apt/ubuntu/12.04/amd64/2016.3/SALTSTACK-GPG-KEY.pub',
           }
         }
-        'sid': {
-          apt::soruce {'saltstack':
-            location   => $deb_base_url,
-            release    => 'unstable',
+        'trusty': {
+          apt::source {'saltstack':
+            location   => 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/2016.3',
+            release    => "${::lsbdistcodename}",
             repos      => 'main',
-            key        => $deb_key,
-            key_source => $deb_key_source,
+            key        => 'DE57BFBE',
+            key_source => 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/2016.3/SALTSTACK-GPG-KEY.pub',
+          }
+        }
+        'xenial': {
+          apt::source {'saltstack':
+            location   => 'http://repo.saltstack.com/apt/ubuntu/16.04/amd64/2016.3',
+            release    => "${::lsbdistcodename}",
+            repos      => 'main',
+            key        => 'DE57BFBE',
+            key_source => 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2016.3/SALTSTACK-GPG-KEY.pub',
+          }
+        }
+      }
+    }
+    'Debian': {
+      case $::lsbdistcodename {
+        'wheezy': {
+          apt::source {'saltstack':
+            location   => 'http://repo.saltstack.com/apt/debian/7/amd64/archive/2016.3.1',
+            release    => "${::lsbdistcodename}",
+            repos      => 'main',
+            key        => 'DE57BFBE',
+            key_source => 'http://repo.saltstack.com/apt/debian/7/amd64/archive/2016.3.1/SALTSTACK-GPG-KEY.pub',
+          }
+        }
+        'jessie': {
+          apt::source {'saltstack':
+            location   => 'http://repo.saltstack.com/apt/debian/8/amd64/2016.3',
+            release    => "${::lsbdistcodename}",
+            repos      => 'main',
+            key        => 'DE57BFBE',
+            key_source => 'https://repo.saltstack.com/apt/debian/8/amd64/2016.3/SALTSTACK-GPG-KEY.pub',
           }
         }
         default  : { fail("${::lsbdistcodename} is not yet supported, Add it and send a pull request!") }
@@ -38,4 +63,3 @@ class salt::repo::deb {
   }
 }
 # vim:shiftwidth=2:tabstop=2:softtabstop=2:expandtab:smartindent
-

--- a/manifests/repo/deb.pp
+++ b/manifests/repo/deb.pp
@@ -6,57 +6,23 @@ class salt::repo::deb {
 
   case $::operatingsystem {
     'Ubuntu': {
-      case $::lsbdistcodename {
-        'precise': {
-          apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/ubuntu/12.04/amd64/archive/2016.3.2',
-            release    => "${::lsbdistcodename}",
-            repos      => 'main',
-            key        => 'DE57BFBE',
-            key_source => 'https://repo.saltstack.com/apt/ubuntu/12.04/amd64/archive/2016.3.2/SALTSTACK-GPG-KEY.pub',
-          }
-        }
-        'trusty': {
-          apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.2',
-            release    => "${::lsbdistcodename}",
-            repos      => 'main',
-            key        => 'DE57BFBE',
-            key_source => 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.2/SALTSTACK-GPG-KEY.pub',
-          }
-        }
-        'xenial': {
-          apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/ubuntu/16.04/amd64/archive/2016.3.2',
-            release    => "${::lsbdistcodename}",
-            repos      => 'main',
-            key        => 'DE57BFBE',
-            key_source => 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/archive/2016.3.2/SALTSTACK-GPG-KEY.pub',
-          }
-        }
+      $os_string = $::os['release']['full']
+      apt::source {'saltstack':
+        location   => "http://repo.saltstack.com/apt/ubuntu/${os_string}/amd64/2016.11",
+        release    => "${::lsbdistcodename}",
+        repos      => 'main',
+        key        => 'DE57BFBE',
+        key_source => "https://repo.saltstack.com/apt/ubuntu/${os_string}/amd64/2016.11/SALTSTACK-GPG-KEY.pub",
       }
     }
     'Debian': {
-      case $::lsbdistcodename {
-        'wheezy': {
-          apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/debian/7/amd64/archive/2016.3.1',
-            release    => "${::lsbdistcodename}",
-            repos      => 'main',
-            key        => 'DE57BFBE',
-            key_source => 'http://repo.saltstack.com/apt/debian/7/amd64/archive/2016.3.1/SALTSTACK-GPG-KEY.pub',
-          }
-        }
-        'jessie': {
-          apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/debian/8/amd64/archive/2016.3.2',
-            release    => "${::lsbdistcodename}",
-            repos      => 'main',
-            key        => 'DE57BFBE',
-            key_source => 'https://repo.saltstack.com/apt/debian/8/amd64/archive/2016.3.2/SALTSTACK-GPG-KEY.pub',
-          }
-        }
-        default  : { fail("${::lsbdistcodename} is not yet supported, Add it and send a pull request!") }
+      $os_string = $::os['release']['major']
+      apt::source {'saltstack':
+        location   => "http://repo.saltstack.com/apt/debian/${os_string}/amd64/2016.11",
+        release    => "${::lsbdistcodename}",
+        repos      => 'main',
+        key        => 'DE57BFBE',
+        key_source => "https://repo.saltstack.com/apt/debian/${os_string}/amd64/2016.11/SALTSTACK-GPG-KEY.pub",
       }
     }
     default: { fail("${::operatingsystem} is not yet supported, Add it and send a pull request!") }

--- a/manifests/repo/deb.pp
+++ b/manifests/repo/deb.pp
@@ -9,29 +9,29 @@ class salt::repo::deb {
       case $::lsbdistcodename {
         'precise': {
           apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/ubuntu/12.04/amd64/2016.3',
+            location   => 'http://repo.saltstack.com/apt/ubuntu/12.04/amd64/archive/2016.3.2',
             release    => "${::lsbdistcodename}",
             repos      => 'main',
             key        => 'DE57BFBE',
-            key_source => 'https://repo.saltstack.com/apt/ubuntu/12.04/amd64/2016.3/SALTSTACK-GPG-KEY.pub',
+            key_source => 'https://repo.saltstack.com/apt/ubuntu/12.04/amd64/archive/2016.3.2/SALTSTACK-GPG-KEY.pub',
           }
         }
         'trusty': {
           apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/2016.3',
+            location   => 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.2',
             release    => "${::lsbdistcodename}",
             repos      => 'main',
             key        => 'DE57BFBE',
-            key_source => 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/2016.3/SALTSTACK-GPG-KEY.pub',
+            key_source => 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2016.3.2/SALTSTACK-GPG-KEY.pub',
           }
         }
         'xenial': {
           apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/ubuntu/16.04/amd64/2016.3',
+            location   => 'http://repo.saltstack.com/apt/ubuntu/16.04/amd64/archive/2016.3.2',
             release    => "${::lsbdistcodename}",
             repos      => 'main',
             key        => 'DE57BFBE',
-            key_source => 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2016.3/SALTSTACK-GPG-KEY.pub',
+            key_source => 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/archive/2016.3.2/SALTSTACK-GPG-KEY.pub',
           }
         }
       }
@@ -49,11 +49,11 @@ class salt::repo::deb {
         }
         'jessie': {
           apt::source {'saltstack':
-            location   => 'http://repo.saltstack.com/apt/debian/8/amd64/2016.3',
+            location   => 'http://repo.saltstack.com/apt/debian/8/amd64/archive/2016.3.2',
             release    => "${::lsbdistcodename}",
             repos      => 'main',
             key        => 'DE57BFBE',
-            key_source => 'https://repo.saltstack.com/apt/debian/8/amd64/2016.3/SALTSTACK-GPG-KEY.pub',
+            key_source => 'https://repo.saltstack.com/apt/debian/8/amd64/archive/2016.3.2/SALTSTACK-GPG-KEY.pub',
           }
         }
         default  : { fail("${::lsbdistcodename} is not yet supported, Add it and send a pull request!") }

--- a/templates/grains.erb
+++ b/templates/grains.erb
@@ -3,6 +3,13 @@ facter:
 scope.compiler.topscope.to_hash.reject do |k,v|
   k.to_s =~ /(uptime.*|last_run|timestamp|(memory|swap)free|ssh*)/ or ! v.is_a?(String)
 end.sort.each do |fact| -%>
-  <%= fact[0] -%>: 
+  <%= fact[0] -%>:
     - <%= fact[1] %>
 <% end %>
+<% if @minion_grains -%>
+<% @minion_grains.each do |key, value| -%>
+<% if value.is_a?(String) -%>
+<%= key -%>: <%= value %>
+<% end -%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Configuration options passed to ::salt class were never inherited by the templates. E.g. defining minion_master invoked no change in config file.
